### PR TITLE
Fix build on RTD (myst install, include.txt, and Canonical-sphinx)

### DIFF
--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -28,6 +28,6 @@ sphinx:
 #    - pdf
 
 # Optionally declare the Python requirements required to build your docs
-# python:
-#    install:
-#    - requirements: docs/requirements.txt
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -39,3 +39,14 @@ html_context = {
 }
 
 html_favicon = '_static/favicon.png'
+
+rst_prolog = """
+.. role:: center
+   :class: align-center
+.. role:: h2
+    :class: hclass2
+.. role:: woke-ignore
+    :class: woke-ignore
+.. role:: vale-ignore
+    :class: vale-ignore
+"""

--- a/docs/content/include.txt
+++ b/docs/content/include.txt
@@ -1,0 +1,3 @@
+[include_start]
+I feel included!
+[include_end]

--- a/docs/content/myst-cheat-sheet.md
+++ b/docs/content/myst-cheat-sheet.md
@@ -175,7 +175,7 @@ Keys can be defined at the top of a file, or in a `myst_substitutions` option in
    :end-before: [include_end]
 ```
 
-## Tabs
+<!-- ## Tabs
 
 ````{tab-set}
 ```{tab-item} Tab 1
@@ -186,7 +186,7 @@ Content Tab 1
 ```{tab-item} Tab 2
 Content Tab 2
 ```
-````
+```` -->
 
 ## Glossary
 
@@ -205,16 +205,16 @@ some term
 
 ----
 
-## Custom extensions
+<!-- ## Custom extensions
 
 Related links at the top of the page (surrounded by `---`):
 
     relatedlinks: https://github.com/canonical/lxd-sphinx-extensions, [RTFM](https://www.google.com)
-    discourse: 12345
+    discourse: 12345 -->
 
-Terms that should not be checked by the spelling checker: {spellexception}`PurposelyWrong`
+<!-- Terms that should not be checked by the spelling checker: {spellexception}`PurposelyWrong` -->
 
-A single-line terminal view that separates input from output:
+<!-- A single-line terminal view that separates input from output:
 
 ```{terminal}
    :input: command
@@ -242,4 +242,4 @@ A link to a YouTube video:
 
 ```{youtube} https://www.youtube.com/watch?v=iMLiK1fX4I0
    :title: Demo
-```
+``` -->

--- a/docs/content/rst-cheat-sheet.rst
+++ b/docs/content/rst-cheat-sheet.rst
@@ -208,18 +208,18 @@ Reuse
    :start-after: [include_start]
    :end-before: [include_end]
 
-Tabs
-----
+.. Tabs
+.. ----
 
-.. tab-set::
+.. .. tab-set::
 
-   .. tab-item:: Tab 1
+..    .. tab-item:: Tab 1
 
-      Content Tab 1
+..       Content Tab 1
 
-   .. tab-item:: Tab 2
+..    .. tab-item:: Tab 2
 
-      Content Tab 2
+..       Content Tab 2
 
 
 Glossary
@@ -244,42 +244,42 @@ More useful markup
 
 ----
 
-Custom extensions
------------------
+.. Custom extensions
+.. -----------------
 
-Related links at the top of the page::
+.. Related links at the top of the page::
 
-  :relatedlinks: https://github.com/canonical/lxd-sphinx-extensions, [RTFM](https://www.google.com)
-  :discourse: 12345
+..   :relatedlinks: https://github.com/canonical/lxd-sphinx-extensions, [RTFM](https://www.google.com)
+..   :discourse: 12345
 
-Terms that should not be checked by the spelling checker: :spellexception:`PurposelyWrong`
+.. Terms that should not be checked by the spelling checker: :spellexception:`PurposelyWrong`
 
-A single-line terminal view that separates input from output:
+.. A single-line terminal view that separates input from output:
 
-.. terminal::
-   :input: command
-   :user: root
-   :host: vampyr
-   :dir: /home/user/directory/
+.. .. terminal::
+..    :input: command
+..    :user: root
+..    :host: vampyr
+..    :dir: /home/user/directory/
 
-   the output
+..    the output
 
-A multi-line version of the same:
+.. A multi-line version of the same:
 
-.. terminal::
-   :user: root
-   :host: vampyr
-   :dir: /home/user/directory/
+.. .. terminal::
+..    :user: root
+..    :host: vampyr
+..    :dir: /home/user/directory/
 
-   :input: command 1
-   output 1
-   :input: command 2
-   output 2
+..    :input: command 1
+..    output 1
+..    :input: command 2
+..    output 2
 
-A link to a YouTube video:
+.. A link to a YouTube video:
 
-.. youtube:: https://www.youtube.com/watch?v=iMLiK1fX4I0
-          :title: Demo
+.. .. youtube:: https://www.youtube.com/watch?v=iMLiK1fX4I0
+..           :title: Demo
 
 
 


### PR DESCRIPTION
Fix build by:
- Make sure to install MyST parser by enabling `requirements.txt` installation step for the ReadtheDocs
- Add `include.txt` and some styles definition in `conf.py`
- Remove unsupported features from Canonical-sphinx extensions (to be returned after we update the Ulwazi to the latest Starter pack base)