### PR TITLE
Add skip links

### DIFF
--- a/ulwazi/theme/ulwazi/page.html
+++ b/ulwazi/theme/ulwazi/page.html
@@ -4,7 +4,8 @@
 {% block body %}
 {% block header %}
 <header>
-    {% include "sections/header.html" %}
+  <a href="#content" class="p-link--skip">Jump to main content</a>
+  {% include "sections/header.html" %}
 </header>
 {% endblock header %}
 {% block announcement %}
@@ -35,7 +36,7 @@
       {% include "sections/sidebar-primary.html" %}
     </aside>
     {% endblock sidebar_primary %}
-    <main class="sb-main">
+    <main class="sb-main" id="content">
       {% block header_content %}
       <header class="sb-header-content">
         <div class="sb-header-content__inner">


### PR DESCRIPTION
Adds skip links to the top of each page that jump to the main content, following the [Vanilla Theme's skip link implementation](https://vanillaframework.io/docs/patterns/links#skip-link). 