### PR TITLE
Simplify HTML for inline code

### DIFF
--- a/docs/content/test7_admonitionsMD.md
+++ b/docs/content/test7_admonitionsMD.md
@@ -1,10 +1,11 @@
 # Tests for Admonitions in Markdown
 
+This `is an inline code test` in `markdown`.
+
 :::{note}
 :name: note-reference
 This note admonition has a reference target name that is referenced at the bottom of this page.
 :::
-
 
 ```{attention}
 This is an Attention admonition

--- a/ulwazi/__init__.py
+++ b/ulwazi/__init__.py
@@ -5,7 +5,6 @@ from typing import Any, Dict
 import sphinx.application
 from .navigation import get_navigation_tree
 from bs4 import BeautifulSoup
-import re
 
 THEME_PATH = (Path(__file__).parent / "theme" / "ulwazi").resolve()
 

--- a/ulwazi/__init__.py
+++ b/ulwazi/__init__.py
@@ -5,6 +5,7 @@ from typing import Any, Dict
 import sphinx.application
 from .navigation import get_navigation_tree
 from bs4 import BeautifulSoup
+import re
 
 THEME_PATH = (Path(__file__).parent / "theme" / "ulwazi").resolve()
 
@@ -45,7 +46,8 @@ def config_inited(app, config):  # noqa: ANN401
     extra_js = [
         "js/scripts.js",
         "js/header-nav.js",
-        "js/dropdown.js"
+        "js/dropdown.js",
+        "js/prism.js"
     ]
 
     values_and_defaults = [
@@ -114,7 +116,6 @@ def apply_admonition_classes(body_html:str) -> str:
     admonitions = soup.find_all(class_="admonition")
     generic = soup.find_all(class_="admonition-generic-admonition")
 
-
     for admonition in admonitions:
         child_tags = admonition.findChildren()
         div_tag = soup.new_tag('div')
@@ -173,9 +174,28 @@ def apply_admonition_classes(body_html:str) -> str:
 
     return str(soup)
 
+def modify_inline_code(body_html: str) -> str:
+    """Modify inline code elements in the HTML."""
+    if not body_html:
+        return body_html
+
+    soup = BeautifulSoup(body_html, "html.parser")
+
+    for code in soup.find_all("code", class_="docutils literal notranslate"):
+        child_tags = code.findChildren()
+        child_text = []
+        for child in child_tags:
+            child_text.append(child.string)
+            child.decompose()
+
+        code.string = " ".join(child_text)
+        code["class"] = []
+
+    return str(soup)
+
 def _html_page_context(
     app: sphinx.application.Sphinx,
-    pagename: str,
+    pagename: str,  
     templatename: str,
     context: Dict[str, Any],
     doctree: Any,
@@ -188,3 +208,4 @@ def _html_page_context(
     if "body" in context:
         context["body"] = apply_heading_classes(context["body"])
         context["body"] = apply_admonition_classes(context["body"])
+        context["body"] = modify_inline_code(context["body"])

--- a/ulwazi/__init__.py
+++ b/ulwazi/__init__.py
@@ -194,7 +194,7 @@ def modify_inline_code(body_html: str) -> str:
 
 def _html_page_context(
     app: sphinx.application.Sphinx,
-    pagename: str,  
+    pagename: str,
     templatename: str,
     context: Dict[str, Any],
     doctree: Any,

--- a/ulwazi/__init__.py
+++ b/ulwazi/__init__.py
@@ -189,7 +189,8 @@ def modify_inline_code(body_html: str) -> str:
             child.decompose()
 
         code.string = " ".join(child_text)
-        code["class"] = []
+        if "class" in code.attrs:
+            del code["class"]
 
     return str(soup)
 

--- a/ulwazi/__init__.py
+++ b/ulwazi/__init__.py
@@ -46,8 +46,7 @@ def config_inited(app, config):  # noqa: ANN401
     extra_js = [
         "js/scripts.js",
         "js/header-nav.js",
-        "js/dropdown.js",
-        "js/prism.js"
+        "js/dropdown.js"
     ]
 
     values_and_defaults = [


### PR DESCRIPTION
## Default inline code behavior

Inline code renders as expected out of the box for both rST and Markdown files:

```
# rST
This ``is an inline code test``

# markdown
This `is an inline code test`
```

<img width="299" height="45" alt="image" src="https://github.com/user-attachments/assets/5a242300-e0fa-49bd-9c2a-3f81602f0bc4" />

However, the HTML generated by Sphinx/docutils looks as follows:

```html
<p>This
  <code class="docutils literal notranslate">
    <span class="pre">is</span>
    <span class="pre">an</span>
    <span class="pre">inline</span>
    <span class="pre">code</span>
    <span class="pre">test</span>
  </code>
</p>
```

## Vanilla modifications

To achieve the [Vanilla style](https://vanillaframework.io/docs/base/code#inline) of just one `<code>` tag, a new function was added to modify the HTML for inline code blocks. 

The function:

* Removes the docutils class from the `<code>` tag
* Removes the `<span>` tags for each literal

Now the output HTML looks as follows:

```html
<p>This
  <code> is an inline code test</code>
</p>
```