### PR TITLE
Enable Pygments for syntax highlighting

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -306,6 +306,11 @@ exclude_patterns = [
 # html_js_files = []
 
 
+# Syntax highlighting settings
+
+highlight_language = "none" # default
+pygments_style = "autumn" # see https://pygments.org/styles for more
+
 # Specifies a reST snippet to be appended to each .rst file
 
 rst_epilog = """

--- a/docs/content/myst-cheat-sheet.md
+++ b/docs/content/myst-cheat-sheet.md
@@ -42,8 +42,8 @@ Start a code block:
     code:
       - example: true
 
-```
-# Demonstrate a code block
+```text
+# Demonstrate a code block w/o syntax highlighting
 code:
   - example: true
 ```
@@ -52,6 +52,63 @@ code:
 # Demonstrate a code block
 code:
   - example: true
+```
+
+### Syntax highlighting
+
+YAML:
+
+```yaml
+# Required
+version: 2
+
+# Set the version of Python and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+  jobs:
+    post_create_environment:
+    - pip install sphinx build
+    - python -m build
+    - pip install dist/ulwazi-0.1.tar.gz
+    post_checkout:
+    - git fetch --unshallow || true
+
+# Build documentation in the docs/ directory with Sphinx
+sphinx:
+  builder: dirhtml
+  configuration: docs/conf.py
+  fail_on_warning: true
+
+# If using Sphinx, optionally build your docs in additional formats such as PDF
+formats:
+- pdf
+
+# Optionally declare the Python requirements required to build your docs
+python:
+  install:
+  - requirements: requirements.txt
+```
+
+Python:
+
+```python
+import datetime
+import os
+import yaml
+
+copyright = "%s CC-BY-SA, %s" % (datetime.date.today().year, author)
+
+if "READTHEDOCS_VERSION" in os.environ:
+    version = os.environ["READTHEDOCS_VERSION"]
+    sitemap_url_scheme = "{version}{link}"
+else:
+    sitemap_url_scheme = "MANUAL/{link}"
+
+if os.path.exists("./reuse/substitutions.yaml"):
+    with open("./reuse/substitutions.yaml", "r") as fd:
+        myst_substitutions = yaml.safe_load(fd.read())
 ```
 
 (a_section_target_myst)=

--- a/docs/content/myst-cheat-sheet.md
+++ b/docs/content/myst-cheat-sheet.md
@@ -91,6 +91,19 @@ python:
   - requirements: requirements.txt
 ```
 
+Shell:
+
+```shell
+# Create and activate a virtual environment
+python3 -m venv .venv && source .venv/bin/activate
+
+# Install Sphinx and the RTD theme
+pip install sphinx sphinx-rtd-theme
+
+# Build HTML docs from the "docs" folder
+sphinx-build -b html docs/ _build/html
+```
+
 Python:
 
 ```python

--- a/docs/content/rst-cheat-sheet.rst
+++ b/docs/content/rst-cheat-sheet.rst
@@ -99,6 +99,19 @@ YAML:
      install:
      - requirements: requirements.txt
 
+Shell:
+
+.. code-block:: shell
+
+   # Create and activate a virtual environment
+   python3 -m venv .venv && source .venv/bin/activate
+
+   # Install Sphinx and the RTD theme
+   pip install sphinx sphinx-rtd-theme
+
+   # Build HTML docs from the "docs" folder
+   sphinx-build -b html docs/ _build/html
+
 Python:
 
 .. code-block:: python

--- a/docs/content/rst-cheat-sheet.rst
+++ b/docs/content/rst-cheat-sheet.rst
@@ -49,17 +49,75 @@ Start a code block::
      code:
        - example: true
 
-.. code::
+.. code:: text
 
      # Demonstrate a code block
      code:
        - example: true
 
-.. code:: yaml
+.. code-block:: yaml
 
      # Demonstrate a code block
      code:
        - example: true
+
+Syntax highlighting
+~~~~~~~~~~~~~~~~~~~
+
+YAML:
+
+.. code-block:: yaml
+
+   # Required
+   version: 2
+
+   # Set the version of Python and other tools you might need
+   build:
+     os: ubuntu-22.04
+     tools:
+       python: "3.11"
+     jobs:
+       post_create_environment:
+       - pip install sphinx build
+       - python -m build
+       - pip install dist/ulwazi-0.1.tar.gz
+       post_checkout:
+       - git fetch --unshallow || true
+
+   # Build documentation in the docs/ directory with Sphinx
+   sphinx:
+     builder: dirhtml
+     configuration: docs/conf.py
+     fail_on_warning: true
+
+   # If using Sphinx, optionally build your docs in additional formats such as PDF
+   formats:
+   - pdf
+
+   # Optionally declare the Python requirements required to build your docs
+   python:
+     install:
+     - requirements: requirements.txt
+
+Python:
+
+.. code-block:: python
+
+   import datetime
+   import os
+   import yaml
+
+   copyright = "%s CC-BY-SA, %s" % (datetime.date.today().year, author)
+
+   if "READTHEDOCS_VERSION" in os.environ:
+       version = os.environ["READTHEDOCS_VERSION"]
+       sitemap_url_scheme = "{version}{link}"
+   else:
+       sitemap_url_scheme = "MANUAL/{link}"
+
+   if os.path.exists("./reuse/substitutions.yaml"):
+       with open("./reuse/substitutions.yaml", "r") as fd:
+           myst_substitutions = yaml.safe_load(fd.read())
 
 .. _a_section_target:
 


### PR DESCRIPTION
The [Pygments](https://pygments.org/) syntax highlighter is built into our Sphinx tooling, and covers several styles and languages.

To enable it, this PR adds two options to the `conf.py` file:
* `highlight_language = "none"` : sets default highlighting style if a language is not specified in a code block
* `pygments_style = "autumn"` : a style I find nice and complete, but open to suggestions and comments

## Examples

<img width="935" height="1201" alt="image" src="https://github.com/user-attachments/assets/63dca97c-6024-4a11-a61d-10155c21d377" />


