### PR TITLE
Update in page navigation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -186,6 +186,9 @@ html_context = {
 
 # slug = ''
 
+# Limit the number of levels for Table of contents
+localtoc_max_depth = 3
+
 #######################
 # Sitemap configuration: https://sphinx-sitemap.readthedocs.io/
 #######################

--- a/ulwazi/__init__.py
+++ b/ulwazi/__init__.py
@@ -221,7 +221,13 @@ def modify_local_toc(toc:str) -> str:
         a = li.find("a", recursive=False)
         if a:
             a["class"] = ["p-table-of-contents__link"]
-
+    # Add Back to top button at the end
+    back_to_top = BeautifulSoup(
+                    '<div class="p-top"><a href="#" class="p-top__link">Back to top</a></div>',
+                    "html.parser"
+                    )
+    toc_html.append(back_to_top)
+    
     return str(toc_html)
 
 def _html_page_context(

--- a/ulwazi/__init__.py
+++ b/ulwazi/__init__.py
@@ -12,6 +12,8 @@ THEME_PATH = (Path(__file__).parent / "theme" / "ulwazi").resolve()
 def setup(app):
     app.add_html_theme('ulwazi', str(THEME_PATH))
 
+    app.add_config_value("localtoc_max_depth", None, "html")
+
     app.connect(  # pyright: ignore [reportUnknownMemberType]
         "config-inited",
         config_inited,
@@ -237,6 +239,31 @@ def modify_local_toc(toc:str) -> str:
 
     return str(toc_html)
 
+def truncate_local_toc(toc: str, max_depth: int = None) -> str:
+    """Limit the number of nested levels if localtoc_max_depth is set in conf.py."""
+    if not toc:
+        return toc
+
+    toc_html = BeautifulSoup(toc, "html.parser")
+
+    if max_depth is not None:
+        def trim_ul(ul, depth=1):
+            if depth >= max_depth:
+                # delete all nested <ul> inside <li>
+                for li in ul.find_all("li", recursive=False):
+                    nested = li.find("ul", recursive=False)
+                    if nested:
+                        nested.decompose()
+            else:
+                # recurse into each li's nested ul
+                for li in ul.find_all("li", recursive=False):
+                    nested = li.find("ul", recursive=False)
+                    if nested:
+                        trim_ul(nested, depth + 1)
+
+        trim_ul(toc_html, 1)
+    return str(toc_html)
+
 def _html_page_context(
     app: sphinx.application.Sphinx,
     pagename: str,
@@ -247,10 +274,14 @@ def _html_page_context(
    
     # Values computed from page-level context.
     context["expandable_navigation_tree"] = _compute_navigation_tree(context)
-    
+
     if "toc" in context:
         context["toc"] = modify_local_toc(context["toc"])
-
+        context["toc"] = truncate_local_toc(
+            context["toc"],
+            getattr(app.config, "localtoc_max_depth", None)
+        )
+    
     # Modify the body of the content
     if "body" in context:
         context["body"] = apply_heading_classes(context["body"])

--- a/ulwazi/__init__.py
+++ b/ulwazi/__init__.py
@@ -199,15 +199,29 @@ def modify_local_toc(toc:str) -> str:
     if not toc:
         return toc
     toc_html = BeautifulSoup(toc, "html.parser")
+    # Remove a redundant <ul>
     top_ul = toc_html.find("ul")
     if top_ul:
-        top_ul.unwrap() # Remove the outermost <ul>
+        top_ul.unwrap()
+    # Remove the page title <li>
+    top_li = toc_html.find("li")
+    if top_li:
+        top_li.unwrap()
+    # Remove the link to the page title <a>
+    top_a = toc_html.find("a")
+    if top_a:
+        top_a.decompose()
+    # Remove a redundant margin for headings
+    top_ul = toc_html.find("ul")
+    if top_ul:
+        top_ul.unwrap()
+    # Assign classes from Vanilla Framework
     for li in toc_html.find_all("li"):
         li["class"] = ["p-table-of-contents__item"]
         a = li.find("a", recursive=False)
         if a:
             a["class"] = ["p-table-of-contents__link"]
-    
+
     return str(toc_html)
 
 def _html_page_context(

--- a/ulwazi/__init__.py
+++ b/ulwazi/__init__.py
@@ -194,6 +194,19 @@ def modify_inline_code(body_html: str) -> str:
 
     return str(soup)
 
+def modify_local_toc(toc:str) -> str:
+    """Modify localtoc to apply Vanilla Framework styles"""
+    if not toc:
+        return toc
+
+    toc_html = BeautifulSoup(toc, "html.parser")
+    for li in toc_html.find_all("li"):
+        li["class"] = ["p-table-of-contents__item"]
+        a = li.find("a")
+        if a:
+            a["class"] = ["p-table-of-contents__link"]
+    return str(toc_html)
+
 def _html_page_context(
     app: sphinx.application.Sphinx,
     pagename: str,
@@ -204,6 +217,9 @@ def _html_page_context(
    
     # Values computed from page-level context.
     context["expandable_navigation_tree"] = _compute_navigation_tree(context)
+    
+    if "toc" in context:
+        context["toc"] = modify_local_toc(context["toc"])
 
     # Modify the body of the content
     if "body" in context:

--- a/ulwazi/__init__.py
+++ b/ulwazi/__init__.py
@@ -198,36 +198,43 @@ def modify_local_toc(toc:str) -> str:
     """Modify localtoc to apply Vanilla Framework styles"""
     if not toc:
         return toc
+    
     toc_html = BeautifulSoup(toc, "html.parser")
+
     # Remove a redundant <ul>
     top_ul = toc_html.find("ul")
     if top_ul:
         top_ul.unwrap()
+    
     # Remove the page title <li>
     top_li = toc_html.find("li")
     if top_li:
         top_li.unwrap()
+    
     # Remove the link to the page title <a>
     top_a = toc_html.find("a")
     if top_a:
         top_a.decompose()
+    
     # Remove a redundant margin for headings
     top_ul = toc_html.find("ul")
     if top_ul:
         top_ul.unwrap()
+    
     # Assign classes from Vanilla Framework
     for li in toc_html.find_all("li"):
         li["class"] = ["p-table-of-contents__item"]
         a = li.find("a", recursive=False)
         if a:
             a["class"] = ["p-table-of-contents__link"]
+    
     # Add Back to top button at the end
     back_to_top = BeautifulSoup(
                     '<div class="p-top"><a href="#" class="p-top__link">Back to top</a></div>',
                     "html.parser"
                     )
     toc_html.append(back_to_top)
-    
+
     return str(toc_html)
 
 def _html_page_context(

--- a/ulwazi/__init__.py
+++ b/ulwazi/__init__.py
@@ -198,13 +198,16 @@ def modify_local_toc(toc:str) -> str:
     """Modify localtoc to apply Vanilla Framework styles"""
     if not toc:
         return toc
-
     toc_html = BeautifulSoup(toc, "html.parser")
+    top_ul = toc_html.find("ul")
+    if top_ul:
+        top_ul.unwrap() # Remove the outermost <ul>
     for li in toc_html.find_all("li"):
         li["class"] = ["p-table-of-contents__item"]
-        a = li.find("a")
+        a = li.find("a", recursive=False)
         if a:
             a["class"] = ["p-table-of-contents__link"]
+    
     return str(toc_html)
 
 def _html_page_context(

--- a/ulwazi/theme/ulwazi/localtoc.html
+++ b/ulwazi/theme/ulwazi/localtoc.html
@@ -1,7 +1,15 @@
 {# Sphinx sidebar template: local table of contents. #}
 {%- if display_toc %}
   <div>
-    <!-- <h3><a href="{{ pathto(root_doc)|e }}">{{ _('Table of Contents') }}</a></h3> -->
-    {{ toc }}
+    <aside class="p-table-of-contents">
+      <div class="p-table-of-contents__section">
+        <h2 class="p-table-of-contents__header">On this page</h2>
+        <nav class="p-table-of-contents__nav" aria-label="Table of contents">
+          <ul class="p-table-of-contents__list">
+          {{ toc }}
+          </ul>
+        </nav>
+      </div>
+    </aside>
   </div>
 {%- endif %}

--- a/ulwazi/theme/ulwazi/page.html
+++ b/ulwazi/theme/ulwazi/page.html
@@ -66,7 +66,7 @@
         </div>
         {% endblock content %}
         {% block sidebar_secondary %}
-        <aside class="sb-sidebar-secondary">
+        <aside class="sb-sidebar-secondary is-sticky">
           {% include "sections/sidebar-secondary.html" %}
         </aside>
         {% endblock sidebar_secondary %}

--- a/ulwazi/theme/ulwazi/sections/sidebar-secondary.html
+++ b/ulwazi/theme/ulwazi/sections/sidebar-secondary.html
@@ -1,2 +1,1 @@
-<h4 class="p-table-of-contents__header">ON THIS PAGE</h4>
 {% include "localtoc.html" %}

--- a/ulwazi/theme/ulwazi/static/css/local-toc.css
+++ b/ulwazi/theme/ulwazi/static/css/local-toc.css
@@ -1,0 +1,18 @@
+/* In-page navigation or table of contents (ToC) */
+
+/* Make ToC to stick to the upper edge of the screen when scrolling down */
+
+.sb-content {
+  align-items: flex-start;   /* don't stretch children */
+}
+
+.sb-sidebar-secondary {
+  flex: 0 0 auto;            /* don’t grow/shrink like the article */
+}
+
+.sb-sidebar-secondary.is-sticky {
+  position: sticky;
+  top: 0;                    /* offset for a sticky header */
+  align-self: flex-start;    /* allow sticky inside flex */
+  height: fit-content;       /* shrink-wrap content */
+}

--- a/ulwazi/theme/ulwazi/static/css/vanilla-main.css
+++ b/ulwazi/theme/ulwazi/static/css/vanilla-main.css
@@ -7518,21 +7518,6 @@ h1.p-stepped-list__title + .p-stepped-list__content {
   z-index: 98;
 }
 
-.sb-content {
-  align-items: flex-start;   /* don't stretch children */
-}
-
-.sb-sidebar-secondary {
-  flex: 0 0 auto;            /* don’t grow/shrink like the article */
-}
-
-.sb-sidebar-secondary.is-sticky {
-  position: sticky;
-  top: 0;                    /* adjust if you have a fixed header */
-  align-self: flex-start;    /* allow sticky inside flex */
-  height: fit-content;       /* shrink-wrap content */
-}
-
 .p-navigation__search {
   display: none;
   padding-top: 1rem;

--- a/ulwazi/theme/ulwazi/static/css/vanilla-main.css
+++ b/ulwazi/theme/ulwazi/static/css/vanilla-main.css
@@ -7518,6 +7518,21 @@ h1.p-stepped-list__title + .p-stepped-list__content {
   z-index: 98;
 }
 
+.sb-content {
+  align-items: flex-start;   /* don't stretch children */
+}
+
+.sb-sidebar-secondary {
+  flex: 0 0 auto;            /* don’t grow/shrink like the article */
+}
+
+.sb-sidebar-secondary.is-sticky {
+  position: sticky;
+  top: 0;                    /* adjust if you have a fixed header */
+  align-self: flex-start;    /* allow sticky inside flex */
+  height: fit-content;       /* shrink-wrap content */
+}
+
 .p-navigation__search {
   display: none;
   padding-top: 1rem;

--- a/ulwazi/theme/ulwazi/theme.toml
+++ b/ulwazi/theme/ulwazi/theme.toml
@@ -6,7 +6,8 @@ stylesheets = [
     "css/skeleton.css",
     "css/sidenav.css",
     "css/tasklist.css",
-    "css/vanilla-main.css"
+    "css/local-toc.css",
+    "css/vanilla-main.css",
 ]
 sidebars = [
     "globaltoc.html",


### PR DESCRIPTION
Update local TOC with Vanilla styles.
Make it stick to the top.
Remove page title.
Add Back to top button at the end.
Make a configurable limit to the number of nested levels in local TOC: `localtoc_max_depth`.