### PR TITLE
Test images and update cheat sheets

### DIFF
--- a/docs/content/myst-cheat-sheet.md
+++ b/docs/content/myst-cheat-sheet.md
@@ -295,7 +295,11 @@ This might damage your hardware!
 
 ## Images
 
+Use standard markdown (`![Alt text]()`) for simple images with no caption.
+
 ![Alt text](https://assets.ubuntu.com/v1/b3b72cb2-canonical-logo-166.png)
+
+Use the `{figure}` directive to include a caption, and to reference the image in text.
 
 ```{figure} https://assets.ubuntu.com/v1/b3b72cb2-canonical-logo-166.png
    :width: 100px
@@ -303,6 +307,9 @@ This might damage your hardware!
 
    Figure caption
 ```
+Images can be inserted in-line ![logo] via a substitution. 
+
+[logo]: https://assets.ubuntu.com/v1/b3b72cb2-canonical-logo-166.png
 
 ## Reuse
 

--- a/docs/content/myst-cheat-sheet.md
+++ b/docs/content/myst-cheat-sheet.md
@@ -310,7 +310,7 @@ Use the `{figure}` directive to include a caption, and to reference the image in
 
 Images can be inserted in-line ![logo] via a substitution. 
 
-[logo]: https://assets.ubuntu.com/v1/b3b72cb2-canonical-logo-166.png
+[logo]: https://assets.ubuntu.com/v1/fdd161e2-canonical_logo_16.png
 
 ## Reuse
 

--- a/docs/content/myst-cheat-sheet.md
+++ b/docs/content/myst-cheat-sheet.md
@@ -295,7 +295,7 @@ This might damage your hardware!
 
 ## Images
 
-Use standard markdown (`![Alt text]()`) for simple images with no caption.
+Use `![Alt text]()` for simple images with no caption.
 
 ![Alt text](https://assets.ubuntu.com/v1/b3b72cb2-canonical-logo-166.png)
 

--- a/docs/content/myst-cheat-sheet.md
+++ b/docs/content/myst-cheat-sheet.md
@@ -307,6 +307,7 @@ Use the `{figure}` directive to include a caption, and to reference the image in
 
    Figure caption
 ```
+
 Images can be inserted in-line ![logo] via a substitution. 
 
 [logo]: https://assets.ubuntu.com/v1/b3b72cb2-canonical-logo-166.png

--- a/docs/content/rst-cheat-sheet.rst
+++ b/docs/content/rst-cheat-sheet.rst
@@ -409,7 +409,7 @@ Use ``.. image::`` for simple images without captions.
 
 .. image:: https://assets.ubuntu.com/v1/b3b72cb2-canonical-logo-166.png
 
-Use ``..figure::`` to include a caption, and to reference the image in text.
+Use ``.. figure::`` to include a caption, and to reference the image in text.
 
 .. figure:: https://assets.ubuntu.com/v1/b3b72cb2-canonical-logo-166.png
    :width: 100px

--- a/docs/content/rst-cheat-sheet.rst
+++ b/docs/content/rst-cheat-sheet.rst
@@ -419,8 +419,7 @@ Use ``.. figure::`` to include a caption, and to reference the image in text.
 
 Images can be inserted in-line |logo| via a substitution. 
 
-.. |logo| image:: https://assets.ubuntu.com/v1/b3b72cb2-canonical-logo-166.png
-   :width: 16px
+.. |logo| image:: https://assets.ubuntu.com/v1/fdd161e2-canonical_logo_16.png
 
 
 Reuse

--- a/docs/content/rst-cheat-sheet.rst
+++ b/docs/content/rst-cheat-sheet.rst
@@ -409,7 +409,7 @@ Use ``.. image::`` for simple images without captions.
 
 .. image:: https://assets.ubuntu.com/v1/b3b72cb2-canonical-logo-166.png
 
-Use ``..figure::`` to include a caption, and to reference the image in text.
+Use ``.. figure::`` to include a caption, and to reference the image in text.
 
 .. figure:: https://assets.ubuntu.com/v1/b3b72cb2-canonical-logo-166.png
    :width: 100px
@@ -420,6 +420,8 @@ Use ``..figure::`` to include a caption, and to reference the image in text.
 Images can be inserted in-line |logo| via a substitution. 
 
 .. |logo| image:: https://assets.ubuntu.com/v1/b3b72cb2-canonical-logo-166.png
+   :width: 16px
+
 
 Reuse
 -----

--- a/docs/content/rst-cheat-sheet.rst
+++ b/docs/content/rst-cheat-sheet.rst
@@ -421,10 +421,6 @@ Images can be inserted in-line |logo| via a substitution.
 
 .. |logo| image:: https://assets.ubuntu.com/v1/b3b72cb2-canonical-logo-166.png
 
-```html
-
-```
-
 Reuse
 -----
 

--- a/docs/content/rst-cheat-sheet.rst
+++ b/docs/content/rst-cheat-sheet.rst
@@ -405,14 +405,25 @@ Notes
 
 Images
 ------
+Use ``.. image::`` for simple images without captions.
 
 .. image:: https://assets.ubuntu.com/v1/b3b72cb2-canonical-logo-166.png
+
+Use ``..figure::`` to include a caption, and to reference the image in text.
 
 .. figure:: https://assets.ubuntu.com/v1/b3b72cb2-canonical-logo-166.png
    :width: 100px
    :alt: Alt text
 
    Figure caption
+
+Images can be inserted in-line |logo| via a substitution. 
+
+.. |logo| image:: https://assets.ubuntu.com/v1/b3b72cb2-canonical-logo-166.png
+
+```html
+
+```
 
 Reuse
 -----

--- a/ulwazi/__init__.py
+++ b/ulwazi/__init__.py
@@ -265,23 +265,6 @@ def truncate_local_toc(toc: str, max_depth: int = None) -> str:
         trim_ul(toc_html, 1)
     return str(toc_html)
 
-def apply_image_classes(body_html: str) -> str:
-    """Add custom CSS classes to images in the generated body HTML."""
-    if not body_html:
-        return body_html
-
-    soup = BeautifulSoup(body_html, "html.parser")
-
-    for img in soup.find_all("img"):
-        # Add class "p-image-container__image" to img tags
-        img["class"] = "p-image-container__image"
-        # put img inside a div with class "p-image-container is-highlighted"
-        wrapper = soup.new_tag("div", attrs={"class": "p-image-container is-highlighted"})
-        img.wrap(wrapper)
-
-    return str(soup)
-
-
 def _html_page_context(
     app: sphinx.application.Sphinx,
     pagename: str,
@@ -305,4 +288,3 @@ def _html_page_context(
         context["body"] = apply_heading_classes(context["body"])
         context["body"] = apply_admonition_classes(context["body"])
         context["body"] = modify_inline_code(context["body"])
-        context["body"] = apply_image_classes(context["body"])

--- a/ulwazi/__init__.py
+++ b/ulwazi/__init__.py
@@ -265,6 +265,23 @@ def truncate_local_toc(toc: str, max_depth: int = None) -> str:
         trim_ul(toc_html, 1)
     return str(toc_html)
 
+def apply_image_classes(body_html: str) -> str:
+    """Add custom CSS classes to images in the generated body HTML."""
+    if not body_html:
+        return body_html
+
+    soup = BeautifulSoup(body_html, "html.parser")
+
+    for img in soup.find_all("img"):
+        # Add class "p-image-container__image" to img tags
+        img["class"] = "p-image-container__image"
+        # put img inside a div with class "p-image-container is-highlighted"
+        wrapper = soup.new_tag("div", attrs={"class": "p-image-container is-highlighted"})
+        img.wrap(wrapper)
+
+    return str(soup)
+
+
 def _html_page_context(
     app: sphinx.application.Sphinx,
     pagename: str,
@@ -288,3 +305,4 @@ def _html_page_context(
         context["body"] = apply_heading_classes(context["body"])
         context["body"] = apply_admonition_classes(context["body"])
         context["body"] = modify_inline_code(context["body"])
+        context["body"] = apply_image_classes(context["body"])


### PR DESCRIPTION
Most Vanilla guidelines apply to image containers (e.g. highlighting, cover image, aspect ratio between image and container, media elements). These attributes are not natively supported in Sphinx - it would require an extension. 

The default HTML generated for simple images, figures, and in-line images is already compliant with existing Vanilla guidelines.

This PR updates the image sections of the rST and MyST cheat sheets. It does not change any code or HTML/CSS.

---

## Images

`..image ::` (rST) and `![]()` (MyST) generate the following HTML by default:

```html
<p>
  <img alt="Alt text" src="https://assets.ubuntu.com/v1/b3b72cb2-canonical-logo-166.png">
</p>
```

I believe this is compliant with Vanilla, since it does not require any special style or container.

`..figure::` (rST) and `{figure}` (MyST) generate the following HTML by default:

```html
<figure class="align-default" id="id1">
<a class="reference internal image-reference" href="https://assets.ubuntu.com/v1/b3b72cb2-canonical-logo-166.png">
<img alt="Alt text" src="https://assets.ubuntu.com/v1/b3b72cb2-canonical-logo-166.png" style="width: 100px;">
</a>
<figcaption>
<p>
    <span class="caption-text">Figure caption</span>
    <a class="headerlink" href="#id1" title="Link to this image">¶</a>
</p>
</figcaption>
</figure>
```

This complies with [Vanilla guidelines for images with captions](https://vanillaframework.io/docs/patterns/images#image-with-caption), which states:
> When an image needs a caption, it can be wrapped in a `<figure>` element, along with a `<figcaption>`.

The additional `<a>` element with class `reference internal image-reference` seems to be the standard way of making figures clickable with docutils/Sphinx. 

## In-line images

`|my-image|` (rST) and `![my-image]` (MyST) inserted in-line as a substitution generates the following HTML by default:

```html
<p>
  Images can be inserted in-line 
  <img alt="logo" src="https://assets.ubuntu.com/v1/b3b72cb2-canonical-logo-166.png"> 
  via a substitution.
</p>
``` 