### PR TITLE
Add PDF smoke test

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -23,5 +23,8 @@ jobs:
       - name: Build HTML
         run: make html
 
+      - name: Build PDF
+        run: make pdf
+
       - name: Run tests
         run: make test

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -18,7 +18,7 @@ jobs:
           fetch-depth: 0
 
       - name: Install PDF dependencies
-        run: make pdf-prep-force
+        run: sudo make pdf-prep-force
 
       - name: Build SCSS
         run: make vanilla-main

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -17,6 +17,9 @@ jobs:
         with:
           fetch-depth: 0
 
+      - name: Install PDF dependencies
+        run: make pdf-prep-force
+
       - name: Build SCSS
         run: make vanilla-main
       

--- a/docs/content/test7_admonitionsMD.md
+++ b/docs/content/test7_admonitionsMD.md
@@ -2,8 +2,8 @@
 
 This `is an inline code test` in `markdown`.
 
+(note-reference)=
 :::{note}
-:name: note-reference
 This note admonition has a reference target name that is referenced at the bottom of this page.
 :::
 
@@ -51,4 +51,4 @@ This is a warning admonition
 This is a generic admonition
 :::
 
-[This is a reference to the note admonition above](#note-reference)
+{ref}`This is a reference to the note admonition above <note-reference>`

--- a/tests/test_pdf_generation.py
+++ b/tests/test_pdf_generation.py
@@ -4,7 +4,7 @@ import subprocess
 PDF_FILE_PATH = "docs/_build/theulwazithemesample.pdf"
 
 def test_pdf_builds():
-    build_process = subprocess.run("make pdf", shell=True, capture_output=True)
+    build_process = subprocess.run(["make", "pdf"], check=True, timeout=300)
     assert build_process.returncode == 0, "PDF build process failed"
 
 def test_pdf_exists():

--- a/tests/test_pdf_generation.py
+++ b/tests/test_pdf_generation.py
@@ -1,11 +1,6 @@
 import os
-import subprocess
 
 PDF_FILE_PATH = "docs/_build/theulwazithemesample.pdf"
-
-def test_pdf_builds():
-    build_process = subprocess.run(["make", "pdf"], check=True, timeout=300)
-    assert build_process.returncode == 0, "PDF build process failed"
 
 def test_pdf_exists():
     assert os.path.exists(PDF_FILE_PATH), f"Missing PDF: {PDF_FILE_PATH}"

--- a/tests/test_pdf_generation.py
+++ b/tests/test_pdf_generation.py
@@ -1,0 +1,11 @@
+import os
+import subprocess
+
+PDF_FILE_PATH = "docs/_build/theulwazithemesample.pdf"
+
+def test_pdf_builds():
+    build_process = subprocess.run("make pdf", shell=True, capture_output=True)
+    assert build_process.returncode == 0, "PDF build process failed"
+
+def test_pdf_exists():
+    assert os.path.exists(PDF_FILE_PATH), f"Missing PDF: {PDF_FILE_PATH}"


### PR DESCRIPTION
## Description

This PR adds a small, simple test to make sure that:
* the PDF build does not fail
* the PDF output file exists at the expected location

The test is **not** currently suitable for CI runs - it should only be run locally. 

This PR also removes one of the issues with the LaTeX build caused by the reference style in `test7_admonitionsMD.md` by changing a markdown-style anchor reference to a Sphinx-style target reference. 

```md
(section-a)=
## Section A

[This works for PDFs](section-a)
{ref}`This works for PDFs <section-a>`

[This DOESN'T work for PDFs](#section-a)
```

## Additional notes

The PDF continues to render the elements of the Ulwazi theme without any noticeable issues. Future work is needed to make the build more smooth, but the current output is acceptable.

Existing warnings/issues to address in the future:
* **Overfull `\hbox`**: This error doesn't seem to have any noticeable visual consequences, but makes a lot of noise in the build output. It occurs often for the wide width tables in "ReStructured Text cheat sheet > Grid tables".
* **LaTeX Font Warning**: It seems that the builder is trying to use certain font shapes/styles that are not available within the Ubuntu font files we provide (possibly like small caps, or bold italics). I believe that they output a warning and then replace the font with something else.