### PR TITLE
Replace theme.conf with theme.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ The theme files are located in the `ulwazi` folder:
 * `__init__.py` -- initialization script for the theme.
 * `navigation.py` -- modifies the global TOC navigation tree
 * `theme/ulwazi/` -- contains the theme files
-  * theme.conf -- theme configuration file
+  * theme.toml -- theme configuration file
   * static -- static content to be used by the theme without processing
   * other files -- HTML templates for Sphinx using Jinja templating engine
 

--- a/docs/content/contribute.rst
+++ b/docs/content/contribute.rst
@@ -75,8 +75,8 @@ for contributing to this theme:
 - ``ulwazi/__init__.py``  -- Theme initialization and core hooks
 - ``ulwazi/navigation.py``  -- Manages the global TOC navigation tree
 - ``ulwazi/theme/ulwazi/`` -- Contains all theme files:
-  
-  - ``theme.conf``         -- Theme configuration
+
+  - ``theme.toml``         -- Theme configuration
   - ``static/``            -- Static assets (CSS, JS, images)
   - HTML files         -- Jinja templates used by Sphinx (look for ``.html`` files)
 


### PR DESCRIPTION
In the usage guide and the README, `theme.conf` is listed as one of the theme files, yet it does not exist. This PR replaces it with the existing `theme.toml`.