### PR TITLE
Fix code blocks rendering in the Global ToC

### DIFF
--- a/docs/content/test-code-headings.md
+++ b/docs/content/test-code-headings.md
@@ -1,0 +1,13 @@
+# Page title with `code example inserted`
+
+This is a sample page, where the title and all headings have code (monospace font).
+
+Check how it renders in the Global ToC on the left and Local ToC on the right.
+
+## Heading h2 `with code`
+
+Text for section 2.
+
+### Significantly longer sub-heading h3 `with code`
+
+Text for subsection.

--- a/docs/content/test.rst
+++ b/docs/content/test.rst
@@ -13,6 +13,7 @@ Test content.
    test7_admonitionsMD
    test_sphinx_tabs_myst
    test_sphinx_tabs
+   test-code-headings
 
 
 

--- a/ulwazi/navigation.py
+++ b/ulwazi/navigation.py
@@ -6,6 +6,17 @@ import copy
 from bs4 import BeautifulSoup, Tag
 
 
+def _strip_code_tags_from_element(element: Tag) -> None:
+    """Remove code-related tags from an element, keeping only their text content."""
+    for tag_name in ["code", "pre", "kbd", "samp"]:
+        for tag in element.find_all(tag_name):
+            tag.unwrap()
+    
+    # Also remove span tags with code-related classes
+    for span in element.find_all("span", class_=["pre", "docutils", "literal", "notranslate"]):
+        span.unwrap()
+
+
 def _get_navigation_expand_image(soup: BeautifulSoup, href: str = "#", is_active: bool = False) -> Tag:
     icon_down = soup.new_tag("i", attrs={"class": "p-icon--chevron-down"})
     icon_up = soup.new_tag("i", attrs={"class": "p-icon--chevron-up"})
@@ -41,6 +52,10 @@ def get_navigation_tree(toctree_html: str) -> str:
     # We add a proper style for each <a> in the globaltoc
     for element in soup.find_all("a", recursive=True):
         element["class"].append("p-side-navigation__link")
+    
+    # Strip code-related tags from all anchor elements
+    for element in soup.find_all("a", recursive=True):
+        _strip_code_tags_from_element(element)
 
     toctree_checkbox_count = 0
     last_element_with_current = None


### PR DESCRIPTION
...by deleting the code HTML tags and preserving the text content only.

Additionally, added a sample page to test the case.

Previously:
<img width="1573" height="701" alt="Screenshot from 2026-02-12 13-41-11" src="https://github.com/user-attachments/assets/992ffa90-de6a-40ab-a0a8-5ed63ae565fe" />


<img width="669" height="223" alt="Screenshot from 2026-02-12 13-42-43" src="https://github.com/user-attachments/assets/57514d97-8379-42b6-97e7-f3443b1542fc" />

Now:
<img width="345" height="381" alt="Screenshot from 2026-02-12 13-53-05" src="https://github.com/user-attachments/assets/42f1568f-0b9c-4c0e-aa95-95d487bafe24" />

<img width="981" height="97" alt="Screenshot from 2026-02-12 13-49-17" src="https://github.com/user-attachments/assets/5ed90c86-71cd-4fd1-85d8-3fa3fd882fe5" />