### PR TITLE
[Hotfix] Fix absent search field on the search page

### DIFF
--- a/ulwazi/theme/ulwazi/searchbox.html
+++ b/ulwazi/theme/ulwazi/searchbox.html
@@ -1,4 +1,5 @@
 {# Sphinx sidebar template: quick search box. #}
+{%- if builder != "singlehtml" %}
 <search class="l-docs__main" id="searchbox" style="display: none" role="search">
   <!-- <h3 id="searchlabel">{{ _('Quick search') }}</h3> -->
     <div class="row">
@@ -10,3 +11,4 @@
     </div>
 </search>
 <script>document.getElementById('searchbox').style.display = "block"</script>
+{%- endif %}

--- a/ulwazi/theme/ulwazi/searchbox.html
+++ b/ulwazi/theme/ulwazi/searchbox.html
@@ -1,5 +1,4 @@
 {# Sphinx sidebar template: quick search box. #}
-{%- if pagename != "search" and builder != "singlehtml" %}
 <search class="l-docs__main" id="searchbox" style="display: none" role="search">
   <!-- <h3 id="searchlabel">{{ _('Quick search') }}</h3> -->
     <div class="row">
@@ -11,4 +10,3 @@
     </div>
 </search>
 <script>document.getElementById('searchbox').style.display = "block"</script>
-{%- endif %}


### PR DESCRIPTION
Fixed the absent search field by deleting the conditional statement that hides the field specifically on the search page.

Resolves https://github.com/canonical/ulwazi/issues/64