### PR TITLE
Add roadmap

### DIFF
--- a/docs/content/contribute.rst
+++ b/docs/content/contribute.rst
@@ -106,3 +106,4 @@ All contributions are welcome: bug reports, feature requests, and pull requests.
 
    rst-cheat-sheet.rst
    myst-cheat-sheet.md
+   roadmap.md

--- a/docs/content/roadmap.md
+++ b/docs/content/roadmap.md
@@ -1,0 +1,41 @@
+# Ulwazi roadmap
+
+Ulwazi is under active development.
+This roadmap shows the current direction of travel and the major milestones
+we want to reach over the next ~12 months.
+
+This is a living document for the internal team and all contributors.
+Priorities may shift as we learn from adoption and feedback.
+
+## Now (26.04)
+
+These are the goals we are working on in this cycle:
+
+* [x] The theme is published as a Python package
+* [x] Contributors’ (developer) documentation is available
+* [ ] The theme is stable enough for wide internal adoption
+* [ ] The theme is ready to be used with Starter Pack
+* [ ] Early adopters’ (user) documentation is available
+
+## Next (26.10)
+
+These are the goals we plan to work on in the next cycle:
+
+* [ ] The theme is widely used for Canonical's own documentation
+* [ ] There is an established feedback process and technical support/maintenance
+* [ ] The theme is ready to be used outside Canonical (without Canonical branding)
+* [ ] Initial public-theme experience (brand-neutral usage) is supported
+* [ ] Design system consistency and visual refinement are improved
+* [ ] The theme repository is public and ready for external contributions
+* [ ] The theme is validated with code tests and accessibility checks
+* [ ] The theme supports all recommended Sphinx extensions
+
+## Later (post-26.10)
+
+These are the topics we hope to cover later (after the next cycle):
+
+* [ ] Additional extensibility and customization
+* [ ] Full public-theme experience (brand-neutral usage) support
+* [ ] Performance and UX polish
+* [ ] Release process maturity and compatibility policy
+* [ ] Community growth

--- a/docs/content/roadmap.md
+++ b/docs/content/roadmap.md
@@ -2,7 +2,7 @@
 
 Ulwazi is under active development.
 This roadmap shows the current direction of travel and the major milestones
-we want to reach over the next ~12 months.
+we want to reach over the next by end of year 2026.
 
 This is a living document for the internal team and all contributors.
 Priorities may shift as we learn from adoption and feedback.

--- a/docs/content/roadmap.md
+++ b/docs/content/roadmap.md
@@ -13,9 +13,13 @@ These are the goals we are working on in this cycle:
 
 * [x] The theme is published as a Python package
 * [x] Contributors’ (developer) documentation is available
+* [ ] The theme is validated with code tests
 * [ ] The theme is stable enough for wide internal adoption
 * [ ] The theme is ready to be used with Starter Pack
 * [ ] Early adopters’ (user) documentation is available
+* [ ] Plan for switching to Ulwazi as the default theme for the Starter Pack
+* [ ] The theme repository is public and ready for external contributions
+* [ ] Initial public-theme experience (brand-neutral usage) is supported
 
 ## Next (26.10)
 
@@ -24,18 +28,16 @@ These are the goals we plan to work on in the next cycle:
 * [ ] The theme is widely used for Canonical's own documentation
 * [ ] There is an established feedback process and technical support/maintenance
 * [ ] The theme is ready to be used outside Canonical (without Canonical branding)
-* [ ] Initial public-theme experience (brand-neutral usage) is supported
 * [ ] Design system consistency and visual refinement are improved
-* [ ] The theme repository is public and ready for external contributions
-* [ ] The theme is validated with code tests and accessibility checks
+* [ ] The theme has accessibility checks
 * [ ] The theme supports all recommended Sphinx extensions
+* [ ] Full public-theme experience (brand-neutral usage) support
 
 ## Later (post-26.10)
 
 These are the topics we hope to cover later (after the next cycle):
 
 * [ ] Additional extensibility and customization
-* [ ] Full public-theme experience (brand-neutral usage) support
 * [ ] Performance and UX polish
 * [ ] Release process maturity and compatibility policy
 * [ ] Community growth

--- a/docs/content/roadmap.md
+++ b/docs/content/roadmap.md
@@ -27,7 +27,6 @@ These are the goals we plan to work on in the next cycle:
 
 * [ ] The theme is widely used for Canonical's own documentation
 * [ ] There is an established feedback process and technical support/maintenance
-* [ ] The theme is ready to be used outside Canonical (without Canonical branding)
 * [ ] Design system consistency and visual refinement are improved
 * [ ] The theme has accessibility checks
 * [ ] The theme supports all recommended Sphinx extensions

--- a/docs/content/roadmap.md
+++ b/docs/content/roadmap.md
@@ -12,11 +12,11 @@ Priorities may shift as we learn from adoption and feedback.
 These are the goals we are working on in this cycle:
 
 * [x] The theme is published as a Python package
-* [x] Contributors’ (developer) documentation is available
+* [x] Developer documentation for contributors is available
 * [ ] The theme is validated with code tests
 * [ ] The theme is stable enough for wide internal adoption
 * [ ] The theme is ready to be used with Starter Pack
-* [ ] Early adopters’ (user) documentation is available
+* [ ] User documentation for early adopters is available
 * [ ] Plan for switching to Ulwazi as the default theme for the Starter Pack
 * [ ] The theme repository is public and ready for external contributions
 * [ ] Initial public-theme experience (brand-neutral usage) is supported


### PR DESCRIPTION
Adding a new roadmap document outlining the planned development milestones and goals for the Ulwazi project. The roadmap is structured by timeframes (current, next, and later cycles) and is intended as a living guide for both internal and external contributors.