### PR TITLE
fix: on page toctree directive

### DIFF
--- a/docs/content/test-on-page-toc.rst
+++ b/docs/content/test-on-page-toc.rst
@@ -1,0 +1,15 @@
+Test page with visible TOC
+==========================
+
+This is a sample page to test the on-page table-of-contents (TOC) feature.
+
+The TOC must be visible, without the ``hidden`` option, and it should be rendered where the directive is added.
+
+Check that the pages included in the TOC below are rendered as lists which links correctly to the other pages.
+The pages included in the TOC are randomly picked from the existing pages.
+
+.. toctree::
+   :maxdepth: 1
+
+   test2
+   test4

--- a/docs/content/test.rst
+++ b/docs/content/test.rst
@@ -14,6 +14,7 @@ Test content.
    test_sphinx_tabs_myst
    test_sphinx_tabs
    test-code-headings
+   Visible toctree <test-on-page-toc>
    typography-verification.rst
 
 

--- a/ulwazi/__init__.py
+++ b/ulwazi/__init__.py
@@ -133,6 +133,8 @@ def apply_list_classes(body_html: str) -> str:
     soup = BeautifulSoup(body_html, "html.parser")
     for tag_name, class_name in LIST_STYLES.items():
         for tag in soup.find_all(tag_name):
+            if tag.find_parent(class_="toctree-wrapper"):
+                continue
             existing_classes = tag.get("class", [])
             if class_name not in existing_classes:
                 existing_classes.append(class_name)

--- a/ulwazi/theme/ulwazi/static/css/sidenav.css
+++ b/ulwazi/theme/ulwazi/static/css/sidenav.css
@@ -17,7 +17,7 @@
 }
 
 /* All the toctree styles (default styles from Sphinx) are nullified */
-li[class*=' toctree'], li[class^='toctree'] {
+#drawer li[class*=' toctree'], #drawer li[class^='toctree'] {
     all: unset;
 }
 


### PR DESCRIPTION
Fixes issue #94 .
On-page TOC is now rendered with Sphinx defaults; side navigation TOC follows Vanilla framework.