### PR TITLE
Fix #91 bug: Cookie banner not showing

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -210,7 +210,7 @@ html_context = {
         "license": True,
         # List your footer entries. Accepts HTML tags.
         "entries": [
-            '<a class="js-revoke-cookie-manager" href="#tracker-settings">Manage your tracker settings</a>',
+            '<a href="" class="js-revoke-cookie-manager muted-link">Manage your tracker settings</a>',
         ]
     }
 }
@@ -366,12 +366,12 @@ exclude_patterns = [
 
 # Adds custom CSS files, located under 'html_static_path'
 
-# html_css_files = []
+html_css_files = ["https://assets.ubuntu.com/v1/d86746ef-cookie_banner.css"]
 
 
 # Adds custom JavaScript files, located under 'html_static_path'
 
-# html_js_files = []
+html_js_files = ["https://assets.ubuntu.com/v1/287a5e8f-bundle.js"]
 
 
 # Syntax highlighting settings

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -210,7 +210,7 @@ html_context = {
         "license": True,
         # List your footer entries. Accepts HTML tags.
         "entries": [
-            '<a href="" class="js-revoke-cookie-manager muted-link">Manage your tracker settings</a>',
+            '<a href="#tracker-settings" class="js-revoke-cookie-manager muted-link">Manage your tracker settings</a>',
         ]
     }
 }

--- a/ulwazi/theme/ulwazi/components/analytics.html
+++ b/ulwazi/theme/ulwazi/components/analytics.html
@@ -1,0 +1,18 @@
+<!-- Google Tag Manager -->
+<script>
+(function(w, d, s, l, i) {
+  w[l] = w[l] || [];
+  w[l].push({
+    'gtm.start': new Date().getTime(),
+    event: 'gtm.js'
+  });
+  var f = d.getElementsByTagName(s)[0],
+    j = d.createElement(s),
+    dl = l != 'dataLayer' ? '&l=' + l : '';
+  j.async = true;
+  j.src =
+    'https://www.googletagmanager.com/gtm.js?id=' + i + dl;
+  f.parentNode.insertBefore(j, f);
+})(window, document, 'script', 'dataLayer', 'GTM-KNX3CJC');
+</script>
+<!-- End Google Tag Manager -->

--- a/ulwazi/theme/ulwazi/sections/header.html
+++ b/ulwazi/theme/ulwazi/sections/header.html
@@ -60,6 +60,7 @@
 {% endmacro %}
 
 <header id="navigation" class="p-navigation is-dark">
+  {% include "components/analytics.html" %}
   <a href="#content" class="p-link--skip">Jump to main content</a>
   <div class="l-docs__subgrid">
     <div class="l-docs__sidebar">


### PR DESCRIPTION
Fixed https://github.com/canonical/ulwazi/issues/91 bug.
Added the cookie banner code to the header/footer and css/js files import in `conf.py`.