### PR TITLE
Hotfix: Darkmode fixes

### DIFF
--- a/ulwazi/theme/ulwazi/layout.html
+++ b/ulwazi/theme/ulwazi/layout.html
@@ -67,7 +67,6 @@
   {% block body_javascript -%}
   {% for js in script_files -%}
     {{ js_tag(js) }}
-  <script src="{{ pathto('_static/js/theme-toggle.js', 1) }}"></script>
   {% endfor -%}
   {%- endblock body_javascript -%}
 </body>

--- a/ulwazi/theme/ulwazi/layout.html
+++ b/ulwazi/theme/ulwazi/layout.html
@@ -57,6 +57,15 @@
   {%- endblock head_stylesheets -%}
 
   {% block head_javascript %}
+  <script>
+    // Apply saved theme early to prevent flash of wrong theme on page load.
+    (function () {
+      var theme = localStorage.getItem("ulwazi-theme");
+      if (theme === "is-dark" || theme === "is-light") {
+        document.documentElement.classList.add(theme);
+      }
+    })();
+  </script>
   {% endblock %}
   {% block head_extra %}{% endblock %}
 </head>

--- a/ulwazi/theme/ulwazi/static/js/theme-toggle.js
+++ b/ulwazi/theme/ulwazi/static/js/theme-toggle.js
@@ -5,8 +5,10 @@ document.addEventListener("DOMContentLoaded", () => {
 
   const applyTheme = (themeClass) => { //themeClass can be "is-light", "is-dark"
     body.classList.remove("is-light", "is-dark");
+    document.documentElement.classList.remove("is-light", "is-dark");
     if (themeClass) {
       body.classList.add(themeClass);
+      document.documentElement.classList.add(themeClass);
     }
     if (toggleButton) {
       toggleButton.setAttribute("aria-pressed", themeClass === "is-dark" ? "true" : "false"); //For accessibility

--- a/ulwazi/theme/ulwazi/static/js/theme-toggle.js
+++ b/ulwazi/theme/ulwazi/static/js/theme-toggle.js
@@ -18,8 +18,6 @@ document.addEventListener("DOMContentLoaded", () => {
   const savedTheme = localStorage.getItem(STORAGE_KEY);
   if (savedTheme === "is-light" || savedTheme === "is-dark") {
     applyTheme(savedTheme);
-  } else if (window.matchMedia && window.matchMedia("(prefers-color-scheme: dark)").matches) {
-    applyTheme("is-dark");
   } else {
     applyTheme("is-light");
   }


### PR DESCRIPTION
1. Fix a bug with Dark mode stopped working suddenly after some unrelated changes.
     a. The theme-toggle script was loaded multiple times. One time due to the proper import in init.py in `extra_js` and many more times due to being included in the layout.html template (once for each JS added). My best idea - if it loads an even number of times - it cancells itself out. 
3. Fixed the white flash happening when opening a new page in a dark mode.

Fixes https://github.com/canonical/ulwazi/issues/96